### PR TITLE
Fix for precursor oddball variants

### DIFF
--- a/items/active/weapons/other/precursorpistol/default.frames
+++ b/items/active/weapons/other/precursorpistol/default.frames
@@ -1,0 +1,9 @@
+{
+  "frameGrid": {
+    "size": [ 45, 20 ],
+    "dimensions": [ 4, 1 ],
+    "names": [
+      [ "shoot.1", "shoot.2", "shoot.3", "shoot.4" ]
+    ]
+  }
+}


### PR DESCRIPTION
Forgot the frames file for the precursorpistol line of weapons, here it is